### PR TITLE
Update request url construction for better readability

### DIFF
--- a/dxlelasticsearchclient/client.py
+++ b/dxlelasticsearchclient/client.py
@@ -211,11 +211,16 @@ class ElasticsearchClient(Client):
         :return: Results of the service invocation.
         :rtype: dict
         """
+        if self._elasticsearch_service_unique_id:
+            request_service_id = "/{}".format(
+                self._elasticsearch_service_unique_id)
+        else:
+            request_service_id = ""
+
         # Create the DXL request message.
         request = Request("{}{}/{}".format(
             self._SERVICE_TYPE,
-            "/{}".format(self._elasticsearch_service_unique_id)
-            if self._elasticsearch_service_unique_id else "",
+            request_service_id,
             request_method))
 
         # Set the payload on the request message (Python dictionary to JSON


### PR DESCRIPTION
@krisleonard-mcafee - this addresses the readability / formatting issue that you mentioned to me yesterday. I originally had looked into just indenting [this line](https://github.com/jbarlow-mcafee/opendxl-elasticsearch-client-python/blob/3504e8eb8a5cbfa6932864cefe8e7839db6fe578/dxlelasticsearchclient/client.py?utf8=%E2%9C%93#L218) like we had discussed. This, however, caused pylint to report a PEP 8 infraction for not [aligning the hanging indent for continuation lines](https://www.python.org/dev/peps/pep-0008/#indentation) consistently. I went with doing the assignment of the request service id portion of the URL as a separate if block since the result seems a little more readable than what is currently committed. Let me know if you think differently on this. Thanks!